### PR TITLE
Concern: handle inheritance

### DIFF
--- a/lib/rails_type_id/concern.rb
+++ b/lib/rails_type_id/concern.rb
@@ -29,7 +29,9 @@ module RailsTypeId
       end
 
       def type_id_prefix
-        @_type_id_prefix
+        @_type_id_prefix ||
+          # Handle inheritance by bubbling up if type_id_prefix defined on superclass
+          (superclass.type_id_prefix if superclass.respond_to?(:type_id_prefix))
       end
 
       def from_controller_id_param(type_id_str)


### PR DESCRIPTION
If the type_id_prefix is defined on a superclass, it won't be accessible directly on the child class. Add some logic to check if the superclass has the method and fall back to it instead.